### PR TITLE
Use Set to keep track of copied objects

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
   "env": {
-    "es6": true,
     "node": true
   },
   "extends": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
+    "es6": true,
     "node": true
   },
   "extends": [

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -25,7 +25,7 @@ function patchFn(object, patches, opts) {
     return function(object, keys) {
       return pluckWithCachedShallowCopy(object, keys, cache);
     };
-  }({});
+  }(new Set());
   var root = { "": object };
   var api;
 

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -14,6 +14,17 @@ var move = require("./move");
 var copy = require("./copy");
 var test = require("./test");
 
+var Cache = global.Set || function() {
+  var set = [];
+  set.has = function(value) {
+    return this.indexOf(value) !== -1;
+  };
+  set.add = function(value) {
+    this.push(value);
+  }
+  return set;
+};
+
 function patchFn(object, patches, opts) {
   if (patches.length === 0) {
     return object;
@@ -25,7 +36,7 @@ function patchFn(object, patches, opts) {
     return function(object, keys) {
       return pluckWithCachedShallowCopy(object, keys, cache);
     };
-  }(new Set());
+  }(new Cache());
   var root = { "": object };
   var api;
 

--- a/lib/utils/pluckWithCachedShallowCopy.js
+++ b/lib/utils/pluckWithCachedShallowCopy.js
@@ -2,19 +2,18 @@
 
 var shallowCopy = require("./shallowCopy");
 
-function fetch(object, key, path, cache) {
-  if (!cache[path]) {
-    cache[path] = {};
-    return cache[path][key] = shallowCopy(object[key]);
+function fetch(object, key, cache) {
+  var value = object[key];
+  if (!cache.has(value)) {
+    value = shallowCopy(value);
+    cache.add(value);
   }
-  return cache[path][key] || (cache[path][key] = shallowCopy(object[key]));
+  return value;
 }
 
 function pluckWithCachedShallowCopy(object, keys, cache) {
-  var path = "";
   for (var i = 0, imax = keys.length - 1; i < imax; i++) {
-    object = object[keys[i]] = fetch(object, keys[i], path, cache);
-    path = path + "/" + keys[i];
+    object = object[keys[i]] = fetch(object, keys[i], cache);
   }
   return object;
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "include": [
       "lib/**/*.js"
     ],
-    "require": [
-      "babel-register"
-    ],
     "sourceMap": false,
     "instrument": false
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
 --recursive
---require babel-register

--- a/test/utils/pluckWithCachedShallowCopy.js
+++ b/test/utils/pluckWithCachedShallowCopy.js
@@ -18,7 +18,7 @@ describe("utils/pluckWithCachedShallowCopy", () => {
       },
       qux: "quux"
     };
-    cache = {};
+    cache = new Set();
   });
 
   it("works", () => {


### PR DESCRIPTION
This allows for the cache to be as efficient (perhaps more) as it was, but avoids bugs where the results of the operations change the path location of copied objects.

See https://github.com/mohayonao/json-touch-patch/issues/9

It does this by using a `Set` (or an array in older environments) to remember objects that have already been cloned to avoid re-cloning them.

What do you think?